### PR TITLE
Record list of specs within agent and create wrapper script to create and install agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ specs.txt
 *.rvm
 *.jar
 *.class
+props/classes

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 specs.txt
+
+*.aj
+*.rvm
+*.jar
+*.class

--- a/make-agent.sh
+++ b/make-agent.sh
@@ -33,6 +33,9 @@ function build_agent() {
         echo "AGENT IS QUIET!"
         javamopagent -emop ${props_dir}/ ${props_dir}/classes -n ${agent_name} -v
     fi
+    # recording the list of specs for fast access by RPP mojo
+    find props -name "*.aj" | grep -v BaseAspect.aj | cut -d/ -f2 | cut -d. -f1 > specs.txt
+    jar -uf ${agent_name}.jar specs.txt
     mv ${agent_name}.jar ${out_dir}
 }
 

--- a/make-agent.sh
+++ b/make-agent.sh
@@ -33,7 +33,7 @@ function build_agent() {
         echo "AGENT IS QUIET!"
         javamopagent -emop ${props_dir}/ ${props_dir}/classes -n ${agent_name} -v
     fi
-    # recording the list of specs for fast access by RPP mojo
+    # recording the list of specs for fast access
     find props -name "*.aj" | grep -v BaseAspect.aj | cut -d/ -f2 | cut -d. -f1 > specs.txt
     jar -uf ${agent_name}.jar specs.txt
     mv ${agent_name}.jar ${out_dir}

--- a/make-and-install-agent.sh
+++ b/make-and-install-agent.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd $( dirname $0 ) && pwd )
+
+cd ${SCRIPT_DIR}/javamop-agent-bundle
+
+echo "Creating agent..."
+bash make-agent.sh props agents quiet
+
+res="$?"
+
+if [ "${res}" -eq 0 ]; then
+    echo
+    echo "Installing agent..."
+    mvn install:install-file -Dfile=agents/JavaMOPAgent.jar -DgroupId="javamop-agent" -DartifactId="javamop-agent" -Dversion="1.0" -Dpackaging="jar"
+else
+    echo "Agent build was unsuccessful, exiting..."
+fi

--- a/make-and-install-agent.sh
+++ b/make-and-install-agent.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR=$( cd $( dirname $0 ) && pwd )
 
-cd ${SCRIPT_DIR}/javamop-agent-bundle
+cd ${SCRIPT_DIR}
 
 echo "Creating agent..."
 bash make-agent.sh props agents quiet


### PR DESCRIPTION
Changes made so that the created JAR contains a file containing the list of specifications contained in the JAR. This is important so that RPP can compute the set of specs that were not included in a potential user-specified list of specs. This PR needs close review, since it is integral for RPP.